### PR TITLE
Remove asm/system.h

### DIFF
--- a/lsi6_lib.c
+++ b/lsi6_lib.c
@@ -9,7 +9,10 @@
 #include <linux/version.h>
 #endif
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
 #include <asm/system.h>
+#endif
+
 #include <asm/io.h>
 #include <asm/irq.h>
 #include <asm/uaccess.h>

--- a/lsi6_main.c
+++ b/lsi6_main.c
@@ -11,7 +11,10 @@
 #include <linux/version.h>
 #endif
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
 #include <asm/system.h>
+#endif
+
 #include <asm/io.h>
 #include <asm/irq.h>
 #include <asm/uaccess.h>


### PR DESCRIPTION
This header was removed from linux kernel since linux 3.4

https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=f05e798ad4c09255f590f5b2c00a7ca6c172f983
